### PR TITLE
fix:Prev/Next button not sticking

### DIFF
--- a/components/tutorial-step.tsx
+++ b/components/tutorial-step.tsx
@@ -51,14 +51,14 @@ export function TutorialStep({
           <CardHeader className="prose">
             <h2 className="p-0 m-0">{title}</h2>
           </CardHeader>
-          <CardContent>
+          <CardContent className="overflow-y-auto h-[calc(100vh-10rem)]">
             <ScrollArea className="h-[calc(100vh-20rem)]">
               <article className="prose prose-sm md:prose-base dark:prose-invert max-w-none">
                 {children}
               </article>
             </ScrollArea>
           </CardContent>
-          <CardFooter className="grid grid-cols-3 gap-2 w-full pt-0 md:pt-4">
+          <CardFooter className="grid grid-cols-3 gap-2 w-full pt-0 md:pt-4 sticky bottom-0 bg-white dark:bg-gray-800">
             {prevPageUrl ? (
               <Button variant="outline" className="w-fit" asChild>
                 <Link href={prevPageUrl}>Previous</Link>


### PR DESCRIPTION
- Issue: Prev/Next buttons in TutorialStep were not consistently positioned at the bottom.
- Solution: Made CardFooter sticky to ensure buttons remain visible.
- Benefits: Improved user experience, easier navigation.

-Before:
 
https://github.com/user-attachments/assets/f95d53ed-9cbb-4ba6-916f-8fb7a47b5a37


- After:

https://github.com/user-attachments/assets/872d8a47-f7d9-4bcf-8144-d47f40cb20c7

